### PR TITLE
Add update job method

### DIFF
--- a/source/Service.js
+++ b/source/Service.js
@@ -576,33 +576,45 @@ class Service extends EventEmitter {
         );
     }
 
-    // updateJob(jobID, mergedProperties = {}, { filterProps = true } = {}) {
-    //     if (!this._initialised) {
-    //         return Promise.reject(newNotInitialisedError());
-    //     }
-    //     return this.jobQueue.enqueue(() =>
-    //         this.getJob(jobID)
-    //             .then(async job => {
-    //                 const updateProps = filterProps
-    //                     ? filterJobInitObject(mergedProperties)
-    //                     : mergedProperties;
-    //                 const updatedJob = merge.recursive(
-    //                     {},
-    //                     job,
-    //                     updateProps
-    //                 );
-    //                 await this.storage.setItem(`job/${job.id}`, updatedJob);
-    //                 this.emit("jobUpdated", {
-    //                     id: job.id,
-    //                     original: job,
-    //                     updated: updatedJob
-    //                 });
-    //             })
-    //             .catch(err => {
-    //                 throw new VError(err, `Failed updating job (${jobID})`);
-    //             })
-    //     );
-    // }
+    /**
+     * Update job options
+     * @typedef {Object} UpdateJobOptions
+     * @property {Boolean=} filterProps - Filter all properties that should
+     *  NOT be overwritten. This is true by default. Using 'false' here may
+     *  result in unpredictable and dangerous behaviour. Use at our own
+     *  peril.
+     */
+
+    /**
+     * Update a job's properties
+     * @param {String} jobID The job ID
+     * @param {Object} mergedProperties The properties to merge (overwrite)
+     * @param {UpdateJobOptions=} options Update method options
+     * @memberof Service
+     */
+    updateJob(jobID, mergedProperties = {}, { filterProps = true } = {}) {
+        if (!this._initialised) {
+            return Promise.reject(newNotInitialisedError());
+        }
+        return this.jobQueue.enqueue(() =>
+            this.getJob(jobID)
+                .then(async job => {
+                    const updateProps = filterProps
+                        ? filterJobInitObject(mergedProperties)
+                        : mergedProperties;
+                    const updatedJob = merge.recursive({}, job, updateProps);
+                    await this.storage.setItem(`job/${job.id}`, updatedJob);
+                    this.emit("jobUpdated", {
+                        id: job.id,
+                        original: job,
+                        updated: updatedJob
+                    });
+                })
+                .catch(err => {
+                    throw new VError(err, `Failed updating job (${jobID})`);
+                })
+        );
+    }
 
     /**
      * Attach a helper to the Service instance

--- a/test/integration/jobUpdate.spec.js
+++ b/test/integration/jobUpdate.spec.js
@@ -1,0 +1,51 @@
+const Service = require("../../dist/Service.js");
+const { JOB_PRIORITY_HIGH, JOB_STATUS_STOPPED } = require("../../dist/symbols.js");
+
+describe("Service", function() {
+    beforeEach(function() {
+        this.service = new Service();
+        return this.service
+            .initialise()
+            .then(() => this.service.addJob({ data: { name: "test1" }, type: "test1" }))
+            .then(jobID => {
+                this.jobID = jobID;
+            });
+    });
+
+    describe("when updating jobs", function() {
+        it("can update certain properties", function() {
+            return this.service
+                .updateJob(this.jobID, { type: "test1-1", priority: JOB_PRIORITY_HIGH })
+                .then(() => this.service.getJob(this.jobID))
+                .then(job => {
+                    expect(job.type).to.equal("test1-1");
+                    expect(job.priority).to.equal(JOB_PRIORITY_HIGH);
+                });
+        });
+
+        it("emits 'jobUpdated' event upon update", function() {
+            const prom = new Promise(resolve => {
+                this.service.on("jobUpdated", resolve);
+            });
+            this.service.updateJob(this.jobID, { type: "test1-2" });
+            return prom.then(jobUpdate => {
+                expect(jobUpdate).to.have.property("id", this.jobID);
+                expect(jobUpdate)
+                    .to.have.property("original")
+                    .that.has.property("type", "test1");
+                expect(jobUpdate)
+                    .to.have.property("updated")
+                    .that.has.property("type", "test1-2");
+            });
+        });
+
+        it("can update core properties when enabled", function() {
+            return this.service
+                .updateJob(this.jobID, { status: JOB_STATUS_STOPPED }, { filterProps: false })
+                .then(() => this.service.getJob(this.jobID))
+                .then(job => {
+                    expect(job.status).to.equal(JOB_STATUS_STOPPED);
+                });
+        });
+    });
+});


### PR DESCRIPTION
The `updateJob` method was previously commented-out. This MR adds it back.