### PR TITLE
job archiving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3186,7 +3186,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -3978,7 +3978,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -7660,7 +7660,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/source/Service.js
+++ b/source/Service.js
@@ -430,7 +430,7 @@ class Service extends EventEmitter {
      * @memberof Service
      */
     async queryJobs(query = {}, { limit = Infinity, sort = "created", order = "desc" } = {}) {
-        query.archived = false;
+        query.archived = archived => archived === false || archived === undefined;
         if (!this._initialised) {
             throw newNotInitialisedError();
         }

--- a/source/Service.js
+++ b/source/Service.js
@@ -499,9 +499,7 @@ class Service extends EventEmitter {
             job.predicate.attemptsMax = job.attempts + 1;
         }
         job.status = JOB_STATUS_PENDING;
-        if (job.result.type !== JOB_RESULT_TYPE_FAILURE_SOFT) {
-            job.result.type = JOB_RESULT_TYPE_FAILURE_SOFT;
-        }
+        job.result.type = null;
         await this.storage.setItem(job.id, job);
         this.emit("jobReset", { id: job.id });
     }

--- a/source/Service.js
+++ b/source/Service.js
@@ -249,6 +249,15 @@ class Service extends EventEmitter {
     }
 
     /**
+     * Archive a job so it will be removed from queries
+     * @param {String} jobID The job ID
+     * @memberof Service
+     */
+    async archiveJob(jobID) {
+        return this.updateJob(jobID, { archived: true });
+    }
+
+    /**
      * Get a job by its ID
      * @param {String} jobID The job ID
      * @returns {Promise.<Object|null>} A promise that resolves with the job
@@ -421,6 +430,7 @@ class Service extends EventEmitter {
      * @memberof Service
      */
     async queryJobs(query = {}, { limit = Infinity, sort = "created", order = "desc" } = {}) {
+        query.archived = false;
         if (!this._initialised) {
             throw newNotInitialisedError();
         }

--- a/source/Service.js
+++ b/source/Service.js
@@ -435,7 +435,7 @@ class Service extends EventEmitter {
         }
         query.archived = query.archived
             ? query.archived
-            : archived === false || archived === undefined;
+            : archived => archived === false || archived === undefined;
         const jobStream = await this.storage.streamItems();
         const results = [];
         jobStream.on("data", job => {

--- a/source/Service.js
+++ b/source/Service.js
@@ -253,7 +253,7 @@ class Service extends EventEmitter {
      * @param {String} jobID The job ID
      * @memberof Service
      */
-    async archiveJob(jobID) {
+    archiveJob(jobID) {
         return this.updateJob(jobID, { archived: true });
     }
 
@@ -430,10 +430,10 @@ class Service extends EventEmitter {
      * @memberof Service
      */
     async queryJobs(query = {}, { limit = Infinity, sort = "created", order = "desc" } = {}) {
-        query.archived = archived => archived === false || archived === undefined;
         if (!this._initialised) {
             throw newNotInitialisedError();
         }
+        query.archived = query.archived || archived === undefined;
         const jobStream = await this.storage.streamItems();
         const results = [];
         jobStream.on("data", job => {

--- a/source/Service.js
+++ b/source/Service.js
@@ -433,7 +433,9 @@ class Service extends EventEmitter {
         if (!this._initialised) {
             throw newNotInitialisedError();
         }
-        query.archived = query.archived || archived === undefined;
+        query.archived = query.archived
+            ? query.archived
+            : archived === false || archived === undefined;
         const jobStream = await this.storage.streamItems();
         const results = [];
         jobStream.on("data", job => {

--- a/source/jobGeneration.js
+++ b/source/jobGeneration.js
@@ -25,9 +25,11 @@ const {
  *  timelimit on the Service instance). Set to null to disable timeouts.
  * @property {Number=} attemptsMax - The maximum number of soft failures that can occur
  *  before this job
+ * @property {Boolean=} archived - Determining if job will be excluded from queries or not
  */
 
 const CONFIGURABLE_JOB_KEYS = [
+    "archived",
     "data",
     "parents",
     "predicate",
@@ -39,6 +41,7 @@ const CONFIGURABLE_JOB_KEYS = [
 ];
 const DEFAULT_JOB_TYPE = "generic";
 const JOB_VALIDATION = {
+    archived: [a => typeof a === "boolean"],
     data: [d => typeof d === "object" && d !== null, () => ({})],
     created: [c => c > 0, () => Date.now()],
     parents: [p => Array.isArray(p), () => []],
@@ -100,6 +103,7 @@ function filterJobInitObject(info) {
  * @property {Number|null} timeLimit - Time limitation for the job's
  *  execution. null means no limit.
  * @property {Number} attempts - Number of attempts the job has had
+ * @property {Boolean} archived - True means the job will be archived and excluded from queries
  */
 
 /**
@@ -133,7 +137,8 @@ function generateEmptyJob() {
             completed: null
         },
         timeLimit: null,
-        attempts: 0
+        attempts: 0,
+        archived: false
     };
 }
 

--- a/test/integration/jobCommencement.spec.js
+++ b/test/integration/jobCommencement.spec.js
@@ -193,12 +193,12 @@ describe("Service", function() {
                 .then(() => this.service.stopJob(this.jobID1, Service.JobResult.Timeout));
         });
 
-        it("changes timeout result types to soft fails", function() {
+        it("expects type to be null after reset", function() {
             return this.service
                 .resetJob(this.jobID1)
                 .then(() => this.service.getJob(this.jobID1))
                 .then(job => {
-                    expect(job.result.type).to.equal(Service.JobResult.SoftFailure);
+                    expect(job.result.type).to.equal(null);
                 });
         });
 


### PR DESCRIPTION
- method for archiving, can be called from separate helpers, etc.
- set archived = false on jobcreation
- query only for only archived jobs
- set job result type as null on resetJob

Closes issues #14 and #6  